### PR TITLE
Write NULL to pointers before using them as a destination for device memory allocation.

### DIFF
--- a/Foreign/CUDA/Driver/Marshal.chs
+++ b/Foreign/CUDA/Driver/Marshal.chs
@@ -10,6 +10,8 @@
 --
 --------------------------------------------------------------------------------
 
+{-# LANGUAGE ScopedTypeVariables #-}
+
 module Foreign.CUDA.Driver.Marshal (
 
   -- * Host Allocation
@@ -101,8 +103,9 @@ mallocHostArray flags = doMalloc undefined
   ,                 `Int'
   , combineBitMasks `[AllocFlag]'         } -> `Status' cToEnum #}
   where
-    alloca'  = F.alloca
-    peekHP p = (HostPtr . castPtr) `fmap` peek p
+    alloca' f = F.alloca $ \(ptr :: Ptr (Ptr ())) ->
+                poke ptr nullPtr >> f (castPtr ptr)
+    peekHP p  = (HostPtr . castPtr) `fmap` peek p
 
 
 -- |
@@ -186,7 +189,8 @@ mallocArray = doMalloc undefined
   { alloca'- `DevicePtr a' peekDeviceHandle*
   ,          `Int'                           } -> `Status' cToEnum #}
   where
-    alloca'  = F.alloca
+    alloca' f = F.alloca $ \(ptr :: Ptr (Ptr ())) ->
+                poke ptr nullPtr >> f (castPtr ptr)
 
 
 -- |

--- a/Foreign/CUDA/Runtime/Marshal.chs
+++ b/Foreign/CUDA/Runtime/Marshal.chs
@@ -9,6 +9,8 @@
 --
 --------------------------------------------------------------------------------
 
+{-# LANGUAGE ScopedTypeVariables #-}
+
 module Foreign.CUDA.Runtime.Marshal (
 
   -- * Host Allocation
@@ -93,8 +95,9 @@ mallocHostArray flags = doMalloc undefined
   , cIntConv        `Int64'
   , combineBitMasks `[AllocFlag]'     } -> `Status' cToEnum #}
   where
-    alloca' = F.alloca
-    hptr p  = (HostPtr . castPtr) `fmap` peek p
+    alloca' f = F.alloca $ \(ptr :: Ptr (Ptr ())) ->
+                poke ptr nullPtr >> f (castPtr ptr)
+    hptr p    = (HostPtr . castPtr) `fmap` peek p
 
 
 -- |
@@ -128,8 +131,9 @@ mallocArray = doMalloc undefined
   , cIntConv `Int64'             } -> `Status' cToEnum #}
   where
     -- C-> Haskell doesn't like qualified imports in marshaller specifications
-    alloca' = F.alloca
-    dptr p  = (castDevPtr . DevicePtr) `fmap` peek p
+    alloca' f = F.alloca $ \(ptr :: Ptr (Ptr ())) ->
+                poke ptr nullPtr >> f (castPtr ptr)
+    dptr p    = (castDevPtr . DevicePtr) `fmap` peek p
 
 
 -- |


### PR DESCRIPTION
On a 64-bit architecture, compiling a GHC program that uses the cuda package
with -O sometimes leaves garbage in the high 4 bytes of device pointers. The
CUDA SDK samples seem to NULL out pointers before using them as a destination
for device memory allocation, but I couldn't find any documentation that this is
required. However, this patch solves all my crashing problems.
