### PR TITLE
Fixes for building Cuda on Windows

### DIFF
--- a/Setup.hs
+++ b/Setup.hs
@@ -134,11 +134,10 @@ cudaLibraryBuildInfo :: CudaPath -> Platform -> Version -> IO HookedBuildInfo
 cudaLibraryBuildInfo cudaPath platform@(Platform arch os) ghcVersion = do
   let cudaLibraryPath   = getCudaLibraryPath cudaPath platform
 
-  -- Extra lib dirs are not needed on Windows or Mac OS. On Linux their
+  -- Extra lib dirs are not needed on Mac OS. On Windows or Linux their
   -- lack would cause an error: /usr/bin/ld: cannot find -lcudart
   let extraLibDirs_     = case os of
                             OSX     -> []
-                            Windows -> []
                             _       -> [cudaLibraryPath]
 
   let includeDirs       = [getCudaIncludePath cudaPath]

--- a/Setup.hs
+++ b/Setup.hs
@@ -162,7 +162,11 @@ cudaLibraryBuildInfo cudaPath platform@(Platform arch os) ghcVersion = do
           , ldOptions      = ldOptions_
           , extraLibs      = extraLibs_
           , extraLibDirs   = extraLibDirs_
-          , options        = [(GHC, ghcOptions)]  -- Is this needed for anything?
+          -- Are ghc-options below  needed for anything?
+          -- On Windows they need to be disabled because Cabal does not escape
+          -- them (quotes and backslashes) causing build fails on machines
+          -- with CUDA_PATH containing spaces.
+          , options        = [(GHC, ghcOptions) | os /= Windows]
           , customFieldsBI = [extraOptionsC2Hs]
           }
 


### PR DESCRIPTION
This PR proposes two Windows-specific fixes:
1) [regression] The extra library directory was not being passed, causing configure process to fail to find libraries. I solved it by unifying Windows case with Linux.

2) The package failed to install when CUDA Toolkit was installed under path containing spaces. The `Cabal` library does correct escaping for cc-options, ld-options, extra directories… but not for ghc-options. 
I suppressed outputting ghc-options on Windows, since it was not needed anyway. Alternatively we could put each path in quotes "" and escape all backslashes — something I don't particularly want to do in our Setup.hs (where we have limited access to libraries).