### PR TITLE
Support Cabal v3 in Setup.hs

### DIFF
--- a/Setup.hs
+++ b/Setup.hs
@@ -196,7 +196,11 @@ libraryBuildInfo verbosity profile installPath platform@(Platform arch os) ghcVe
     , extraLibDirs        = extraLibDirs'
     , frameworks          = frameworks'
     , extraFrameworkDirs  = frameworkDirs'
+#if MIN_VERSION_Cabal(3,0,0)
+    , options             = PerCompilerFlavor (if os /= Windows then ghcOptions else []) []
+#else
     , options             = [(GHC, ghcOptions) | os /= Windows]
+#endif
     , customFieldsBI      = [c2hsExtraOptions]
     }
 


### PR DESCRIPTION
The `options` field of the `BuildInfo` struct changed its type starting with Cabal 3.0.0.0; this means that `Setup.hs` did not run anymore with a newer Cabal version. 

For reference, the original error was:

```
[1 of 2] Compiling Main             ( /home/tom/git/cuda/Setup.hs, /home/tom/git/cuda/.stack-work/dist/x86_64-linux-tinfo6/Cabal-3.0.1.0/setup/Main.o )

/home/tom/git/cuda/Setup.hs:199:29: error:
    • Couldn't match expected type ‘PerCompilerFlavor [String]’
                  with actual type ‘[(CompilerFlavor, [[Char]])]’
    • In the ‘options’ field of a record
      In the second argument of ‘($)’, namely
        ‘emptyBuildInfo
           {ccOptions = ccOptions', ldOptions = ldOptions',
            extraLibs = extraLibs', extraGHCiLibs = extraGHCiLibs',
            extraLibDirs = extraLibDirs', frameworks = frameworks',
            extraFrameworkDirs = frameworkDirs',
            options = [(GHC, ghcOptions) | os /= Windows],
            customFieldsBI = [c2hsExtraOptions]}’
      In a stmt of a 'do' block:
        buildInfo' <- addSystemSpecificOptions
                        $ emptyBuildInfo
                            {ccOptions = ccOptions', ldOptions = ldOptions',
                             extraLibs = extraLibs', extraGHCiLibs = extraGHCiLibs',
                             extraLibDirs = extraLibDirs', frameworks = frameworks',
                             extraFrameworkDirs = frameworkDirs',
                             options = [(GHC, ghcOptions) | os /= Windows],
                             customFieldsBI = [c2hsExtraOptions]}
    |
199 |     , options             = [(GHC, ghcOptions) | os /= Windows]
    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

In this PR this is fixed by changing to the correct initialiser behind a version guard, but I'm not sure whether this is the code style that you want.

This same issue applies in [nvvm](https://github.com/tmcdonell/nvvm); a PR was submitted there too.