### PR TITLE
Fix Setup.hs configure

### DIFF
--- a/Setup.hs
+++ b/Setup.hs
@@ -64,7 +64,6 @@ main :: IO ()
 main = defaultMainWithHooks customHooks
   where
     readHook get_verbosity a flags = do
-        noExtraFlags a
         getHookedBuildInfo (fromFlag (get_verbosity flags))
 
     preprocessors = hookedPreProcessors simpleUserHooks
@@ -105,7 +104,6 @@ main = defaultMainWithHooks customHooks
           currentPlatform = hostPlatform lbi
           compilerId_     = compilerId (compiler lbi)
       --
-      noExtraFlags args
       generateAndStoreBuildInfo
           verbosity
           profile


### PR DESCRIPTION
If `Setup.hs configure` is called directly with a component name as an argument, `noExtraFlags` will complain with something like `unrecognised flag: lib:cuda`.