### PR TITLE
Towards nix lib path discovery

### DIFF
--- a/Setup.hs
+++ b/Setup.hs
@@ -233,7 +233,7 @@ cudaLibraries :: Platform -> [String]
 cudaLibraries (Platform _ os) =
   case os of
     OSX -> ["cudadevrt", "cudart_static"]
-    _   -> ["cudart", "cuda"]
+    _   -> ["cudadevrt", "cudart", "cuda"]
 
 cudaGHCiLibraries
     :: Platform

--- a/Setup.hs
+++ b/Setup.hs
@@ -222,7 +222,7 @@ cudaLibraryPaths (Platform arch os) installPath = (</>) <$> [installPath] <*> li
         (Windows, I386)   -> ["lib/Win32"]
         (Windows, X86_64) -> ["lib/x64"]
         (OSX,     _)      -> ["lib"]    -- MacOS does not distinguish 32- vs. 64-bit paths
-        (_,       X86_64) -> ["lib64"]  -- treat all others similarly
+        (_,       X86_64) -> ["lib64", "lib"]  -- Prefer lib64, but the nixpkgs distriubtion of cudatools moves files to lib. - AM
         _                 -> ["lib"]
 
 

--- a/Setup.hs
+++ b/Setup.hs
@@ -233,7 +233,8 @@ cudaLibraries :: Platform -> [String]
 cudaLibraries (Platform _ os) =
   case os of
     OSX -> ["cudadevrt", "cudart_static"]
-    _   -> ["cudadevrt", "cudart", "cuda"]
+    Linux -> ["cudadevrt"]
+    _   -> ["cudart", "cuda"]
 
 cudaGHCiLibraries
     :: Platform

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,4 @@
+{ pkgs ? import <nixpkgs> {} }:
+  pkgs.mkShell {
+    buildInputs = [ pkgs.git pkgs.ghc pkgs.cabal-install ];
+  }


### PR DESCRIPTION
The nix package for cuda seems to move files towards use of a singular path structure for all platforms.  This seems somewhat reasonable but is surprising when we encounter it as clients.   In this PR Ive widened the lib search paths to allow for multiple possible paths per arch/os, and added the nix version the linux search paths.     

In nix terms I was born yesterday so if anyone has a better approach Id like to hear it.  For this Cuda library specifically I wonder if it would be better to only use the search paths to produce error text and encourage all clients to configure some additional env correctly?  Is that already there and Im missing it?

Thanks
A  