### PR TITLE
Add notice about CUDA_PATH in found-cuda message

### DIFF
--- a/Setup.hs
+++ b/Setup.hs
@@ -460,7 +460,7 @@ findCUDAInstallPath verbosity platform = do
   result <- findFirstValidLocation verbosity platform (candidateCUDAInstallPaths verbosity platform)
   case result of
     Just installPath -> do
-      notice verbosity $ printf "Found CUDA toolkit at: %s" installPath
+      notice verbosity $ printf "Found CUDA toolkit at: %s (set CUDA_PATH to override this)" installPath
       return installPath
     Nothing -> die' verbosity cudaNotFoundMsg
 


### PR DESCRIPTION
If someone has two cuda's installed (e.g. cuda 11 by default but a
side-install of cuda 10 in /opt/cuda-10.2, for me), the setup script
chooses the default one and never shows the error message indicating
that CUDA_PATH may be used to override the discovery process. This patch
mentions the environment variable also in the successful case, so that
people like me have a way to figure out that CUDA_PATH exists.