### PR TITLE
setup: Allow fallback to /lib, even on x64 systems

### DIFF
--- a/Setup.hs
+++ b/Setup.hs
@@ -224,7 +224,7 @@ cudaLibraryPath (Platform arch os) installPath =
     [path] -> return $ installPath </> path
     _ -> do
       -- attempt to choose a directory that exists
-      candidates <- filterM doesDirectoryExist libpaths
+      candidates <- filterM (\d -> doesDirectoryExist (installPath </> d)) libpaths
       case candidates of
         [] -> return (installPath </> head libpaths)  -- whatever
         cand:_ -> return (installPath </> cand)


### PR DESCRIPTION
The CUDA packages on Nix (cudatoolkit + nvidia_x11) seem to provide only a /lib directory, not a /lib64. Hence we need a fallback to /lib there. Since I think it can't hurt to enable this fallback generally on x64 systems, I didn't bother trying to detect Nix specifically.