### PR TITLE
chs: fix GHC 9.2+ prim ambiguity in c2hs-processed source files

### DIFF
--- a/cuda/src/Foreign/CUDA/Driver/Marshal.chs
+++ b/cuda/src/Foreign/CUDA/Driver/Marshal.chs
@@ -1185,7 +1185,7 @@ useDeviceHandle :: DevicePtr a -> DeviceHandle
 useDeviceHandle (DevicePtr (Ptr addr#)) =
   CULLong (W64# (wordToWord64# (int2Word# (addr2Int# addr#))))
 
-#if __GLASGOW_HASKELL__ < 904
+#if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ < 902
 {-# INLINE word64ToWord# #-}
 word64ToWord# :: Word# -> Word#
 word64ToWord# x = x

--- a/cuda/src/Foreign/CUDA/Driver/Module/Query.chs
+++ b/cuda/src/Foreign/CUDA/Driver/Module/Query.chs
@@ -131,7 +131,7 @@ useAsCString (BI.SBS ba#) action = IO $ \s0 ->
 unpack :: ShortByteString -> [Char]
 unpack = P.map BI.w2c . BS.unpack
 
-#if __GLASGOW_HASKELL__ < 902
+#if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ < 902
 {-# INLINE wordToWord8# #-}
 wordToWord8# :: Word# -> Word#
 wordToWord8# x = x

--- a/cuda/src/Foreign/CUDA/Driver/Stream.chs
+++ b/cuda/src/Foreign/CUDA/Driver/Stream.chs
@@ -515,7 +515,7 @@ useDeviceHandle :: DevicePtr a -> {# type CUdeviceptr #}
 useDeviceHandle (DevicePtr (Ptr addr#)) =
   CULLong (W64# (wordToWord64# (int2Word# (addr2Int# addr#))))
 
-#if __GLASGOW_HASKELL__ < 904
+#if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ < 902
 {-# INLINE wordToWord64# #-}
 wordToWord64# :: Word# -> Word#
 wordToWord64# x = x


### PR DESCRIPTION
**Branch:** `fix/ghc94-prim-guards`  
**Commit:** `chs: fix GHC 9.2+ prim ambiguity in c2hs-processed source files`

---

Building with GHC 9.2 or later fails with ambiguous occurrence errors:

```
src/Foreign/CUDA/Driver/Stream.chs:516:18: error:
    Ambiguous occurrence `wordToWord64#'
    It could refer to
       either `GHC.Base.wordToWord64#'
           or `Foreign.CUDA.Driver.Stream.wordToWord64#'
```

The .chs files guard local bridge definitions with `#if __GLASGOW_HASKELL__ < N`. c2hs processes .chs files with its own C preprocessor, in which `__GLASGOW_HASKELL__` is undefined (evaluates to `0`). The guard is therefore always TRUE, and the local definitions of `wordToWord64#`, `word64ToWord#`, and `wordToWord8#` are emitted unconditionally into the generated .hs output. GHC 9.2+ exports these same operations from `GHC.Base`/`GHC.Exts`, so the compiler sees a duplicate and correctly rejects it.

The fix changes bare guards of the form `#if __GLASGOW_HASKELL__ < N` to `#if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ < N`. Under c2hs, `defined(__GLASGOW_HASKELL__)` is FALSE so the local definition is stripped. GHC's own CPP pass sees a defined macro and evaluates the version check normally.

Affected: `Driver/Stream.chs`, `Driver/Marshal.chs`, `Driver/Module/Query.chs`.

Tested: c2hs 0.28.8, GHC 9.4.7, CUDA 12.0, Ubuntu 24.04.