### PR TITLE
Setup: pass include paths and CUDA macros to c2hs

### DIFF
--- a/cuda/Setup.hs
+++ b/cuda/Setup.hs
@@ -210,7 +210,19 @@ libraryBuildInfo cwd verbosity profile installPath platform@(Platform arch os) g
                             _      -> ""
       emptyCase         = ["-DUSE_EMPTY_CASE" | versionBranch ghcVersion >= [7,8]]
       blocksExtension   = [ "-U__BLOCKS__" | os == OSX ]
+      -- Pass include dirs, CUDA path macros, and cbits/ to c2hs so that:
+      --   * stubs.h resolves (needs cbits/ and package root in -I)
+      --   * Path.chs resolves CUDA_INSTALL_PATH / CUDA_LIBRARY_PATH string consts
+      --   * CUDA system headers are found without relying on c2hs default search
+      c2hsIncludePaths  = map (("--cppopts=-I" ++) . interpretSymbolicPath cwd) includePaths
+                       ++ [ "--cppopts=-I."        -- package root for cbits/stubs.h
+                          , "--cppopts=-Icbits"    -- cbits/ for compat headers
+                          ]
+      cudaInstallMacro  = "--cppopts=-DCUDA_INSTALL_PATH=\"" ++ escDefPath installPath ++ "\""
+      cudaLibraryMacro  = "--cppopts=-DCUDA_LIBRARY_PATH=\"" ++ escDefPath canonicalLibraryPath ++ "\""
       c2hsOptions       = unwords $ map ("--cppopts="++) ("-E" : archFlag : emptyCase ++ blocksExtension)
+                       ++ c2hsIncludePaths
+                       ++ [cudaInstallMacro, cudaLibraryMacro]
       c2hsExtraOptions  = ("x-extra-c2hs-options", c2hsOptions)
 
       addSystemSpecificOptions :: BuildInfo -> IO BuildInfo


### PR DESCRIPTION
**Branch:** `fix/setup-c2hs-includes`  
**Commit:** `Setup: pass include paths and CUDA macros to c2hs`

---

On Ubuntu 24.04 (and other distributions where the CUDA toolkit installs to a non-standard layout), two separate build failures occur during the c2hs preprocessing stage.

**Failure 1** — `cbits/stubs.h` not found:

```
fatal error: cbits/stubs.h: No such file or directory
c2hs: Error during preprocessing custom header file
```

The .chs files use `#include "cbits/stubs.h"`, which requires the package root to be on the c2hs include path. The current `Setup.hs` does not add it.

**Failure 2** — `CUDA_INSTALL_PATH` undefined in `Foreign.CUDA.Path`:

```
c2hs: C header contains errors:
Cannot find a definition for `CUDA_INSTALL_PATH' in the header file.
```

`Foreign.CUDA.Path` uses `{#const CUDA_INSTALL_PATH#}`. The macro is passed to GHC via `-optc-D` but not forwarded to c2hs via `--cppopts`, so c2hs cannot resolve it.

The fix extends the `x-extra-c2hs-options` generated by `libraryBuildInfo` to include:
- `--cppopts=-I.` and `--cppopts=-Icbits` so relative includes from .chs files resolve
- `--cppopts=-I<cuda_include_dir>` from the detected CUDA installation
- `--cppopts=-DCUDA_INSTALL_PATH=...` and `--cppopts=-DCUDA_LIBRARY_PATH=...`

Tested: c2hs 0.28.8, GHC 9.4.7, CUDA 12.0 and 13.0, Ubuntu 24.04.