### PR TITLE
Prevent SEGFAULT when stub-library is being accessed

### DIFF
--- a/cuda/src/Foreign/CUDA/Driver/Error.chs
+++ b/cuda/src/Foreign/CUDA/Driver/Error.chs
@@ -55,9 +55,6 @@ import Text.Printf
     , CUDA_ERROR_NO_BINARY_FOR_GPU      as NoBinaryForGPU
     , CUDA_ERROR_INVALID_PTX            as InvalidPTX
     , CUDA_ERROR_INVALID_PC             as InvalidPC
-#if CUDA_VERSION >= 11010
-    , CUDA_ERROR_STUB_LIBRARY           as StubLibrary
-#endif
     }
     with prefix="CUDA_ERROR" deriving (Eq, Show) #}
 

--- a/cuda/src/Foreign/CUDA/Driver/Error.chs
+++ b/cuda/src/Foreign/CUDA/Driver/Error.chs
@@ -55,6 +55,9 @@ import Text.Printf
     , CUDA_ERROR_NO_BINARY_FOR_GPU      as NoBinaryForGPU
     , CUDA_ERROR_INVALID_PTX            as InvalidPTX
     , CUDA_ERROR_INVALID_PC             as InvalidPC
+#if CUDA_VERSION >= 11010
+    , CUDA_ERROR_STUB_LIBRARY           as StubLibrary
+#endif
     }
     with prefix="CUDA_ERROR" deriving (Eq, Show) #}
 
@@ -64,6 +67,10 @@ import Text.Printf
 --
 instance Describe Status where
 #if CUDA_VERSION >= 6000
+#if CUDA_VERSION >= 11010
+  -- Prevent SEGFAULT when CUDA stub-library is being accessed.
+  describe StubLibrary = "stub library"
+#endif
   describe status =
     case cuGetErrorString status of
       (Success, msg) -> msg


### PR DESCRIPTION
Sometimes the `libcuda.so` living in the cudatoolkit's `lib/stubs/` directory will get intentionally or unintentionally linked into a program in place of the real user-space driver. If this occurs, any calls to this Haskell library will cause a SEGFAULT on `cuGetErrorString`, which wrongly gives the impression that this library is simply broken and doesn't instruct users where to actually look to fix their issue.